### PR TITLE
Enhance responsive layout and touch usability

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -50,10 +50,13 @@ body {
   text-decoration: none;
   color: inherit;
   transition: box-shadow .3s, transform .3s;
+  min-width: 44px;
+  min-height: 44px;
 }
 .category-card img {
   width: 100%;
-  height: 100%;
+  height: auto;
+  aspect-ratio: 1 / 1;
   object-fit: cover;
 }
 .category-card span {
@@ -129,6 +132,7 @@ body {
 }
 .image-card img {
   width: 100%;
+  height: auto;
   display: block;
 }
 
@@ -138,6 +142,8 @@ body {
   right: 1rem;
   width: 56px;
   height: 56px;
+  min-width: 44px;
+  min-height: 44px;
   border-radius: 50%;
   background: var(--color-primary);
   color: #fff;
@@ -166,8 +172,19 @@ body {
   padding: .5rem .75rem;
   font-size: 1rem;
   cursor: pointer;
+  min-width: 44px;
+  min-height: 44px;
 }
 
-@media (max-width:600px) {
-  .section-card { margin: .5rem; padding: .75rem; }
+@media (max-width:768px) {
+  html { --font-size: 15px; }
+  .category-grid { grid-template-columns: repeat(auto-fill,minmax(150px,1fr)); padding: .75rem; }
+  .section-card { margin: .75rem; padding: .75rem; }
+}
+
+@media (max-width:480px) {
+  html { --font-size: 14px; }
+  .app-header { padding: .75rem; }
+  .category-grid { grid-template-columns: 1fr; padding: .5rem; }
+  .section-card { margin: .5rem; padding: .5rem; }
 }


### PR DESCRIPTION
## Summary
- Add 768px and 480px breakpoints to adjust font sizing, padding, and grid columns
- Make card images responsive using `height:auto` and `aspect-ratio`
- Ensure interactive elements have minimum 44px tap targets

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689fe3e286d4833389b3ed87c1f42649