### PR TITLE
Add descriptive alt text for images

### DIFF
--- a/cabeza_cuello.html
+++ b/cabeza_cuello.html
@@ -33,7 +33,7 @@
   </article>
 
   <figure class="image-card">
-    <img src="./assets/images/cabeza_cuello_1.png" alt="" />
+    <img src="./assets/images/cabeza_cuello_1.png" alt="Ilustración de radioterapia en cabeza y cuello" />
   </figure>
 
   <article class="section-card">
@@ -98,11 +98,11 @@
   </article>
 
   <figure class="image-card">
-    <img src="./assets/images/cabeza_cuello_2.png" alt="" />
+    <img src="./assets/images/cabeza_cuello_2.png" alt="Ejercicio de mandíbula: apertura" />
   </figure>
 
   <figure class="image-card">
-    <img src="./assets/images/cabeza_cuello_3.png" alt="" />
+    <img src="./assets/images/cabeza_cuello_3.png" alt="Ejercicio de mandíbula: cierre" />
   </figure>
 
   <article class="section-card">
@@ -115,7 +115,7 @@
   </article>
 
   <figure class="image-card">
-    <img src="./assets/images/cabeza_cuello_4.png" alt="" />
+    <img src="./assets/images/cabeza_cuello_4.png" alt="Ejercicio de hombro y espalda" />
   </figure>
 
   <article class="section-card">
@@ -123,11 +123,11 @@
   </article>
 
   <figure class="image-card">
-    <img src="./assets/images/cabeza_cuello_5.png" alt="" />
+    <img src="./assets/images/cabeza_cuello_5.png" alt="Ejercicio de cabeza y cuello: inclinación" />
   </figure>
 
   <figure class="image-card">
-    <img src="./assets/images/cabeza_cuello_6.png" alt="" />
+    <img src="./assets/images/cabeza_cuello_6.png" alt="Ejercicio de cabeza y cuello: rotación" />
   </figure>
 
   <div class="font-popup hidden" id="font-popup">

--- a/cancer_gastrico.html
+++ b/cancer_gastrico.html
@@ -26,7 +26,7 @@
   </article>
 
   <figure class="image-card">
-    <img src="./assets/images/cancer_gastrico_1.png" alt="" />
+    <img src="./assets/images/cancer_gastrico_1.png" alt="Ilustración de cáncer gástrico" />
   </figure>
 
   <article class="section-card">
@@ -87,7 +87,7 @@
   </article>
 
   <figure class="image-card">
-    <img src="./assets/images/cancer_gastrico_2.png" alt="" />
+    <img src="./assets/images/cancer_gastrico_2.png" alt="Gráfico de recomendaciones nutricionales" />
   </figure>
 
   <article class="section-card">

--- a/cancer_pelvis.html
+++ b/cancer_pelvis.html
@@ -33,7 +33,7 @@
   </article>
 
   <figure class="image-card">
-    <img src="./assets/images/cancer_pelvis_1.png" alt="" />
+    <img src="./assets/images/cancer_pelvis_1.png" alt="Esquema de radioterapia para la pelvis" />
   </figure>
 
   <article class="section-card">
@@ -76,7 +76,7 @@
   </article>
 
   <figure class="image-card">
-    <img src="./assets/images/cancer_pelvis_2.png" alt="" />
+    <img src="./assets/images/cancer_pelvis_2.png" alt="Ilustración de efectos secundarios" />
   </figure>
 
   <article class="section-card">
@@ -92,7 +92,7 @@
   </article>
 
   <figure class="image-card">
-    <img src="./assets/images/cancer_pelvis_4.png" alt="" />
+    <img src="./assets/images/cancer_pelvis_4.png" alt="Gráfico de recomendaciones digestivas" />
   </figure>
 
   <div class="font-popup hidden" id="font-popup">

--- a/cancer_prostata.html
+++ b/cancer_prostata.html
@@ -20,7 +20,7 @@
   </article>
 
   <figure class="image-card">
-    <img src="./assets/images/cancer_prostata_1.png" alt="" />
+    <img src="./assets/images/cancer_prostata_1.png" alt="Diagrama de la próstata" />
   </figure>
 
   <article class="section-card">
@@ -41,7 +41,7 @@
   </article>
 
   <figure class="image-card">
-    <img src="./assets/images/cancer_prostata_2.png" alt="" />
+    <img src="./assets/images/cancer_prostata_2.png" alt="Ilustración del tratamiento con radioterapia" />
   </figure>
 
   <article class="section-card">

--- a/index.html
+++ b/index.html
@@ -20,37 +20,37 @@
       <h2 class="section-title">Categorías</h2>
       <div class="category-grid">
         <a class="category-card" href="proteccion_radiologica.html">
-          <img src="./assets/images/proteccion_radiologica_0.png" alt="" />
+          <img src="./assets/images/proteccion_radiologica_0.png" alt="Ilustración de protección radiológica" />
           <span>Protección Radiológica</span>
         </a>
 
         <a class="category-card" href="cancer_gastrico.html">
-          <img src="./assets/images/cancer_gastrico_0.png" alt="" />
+          <img src="./assets/images/cancer_gastrico_0.png" alt="Ilustración de cáncer gástrico" />
           <span>Cáncer Gástrico</span>
         </a>
 
         <a class="category-card" href="cancer_pelvis.html">
-          <img src="./assets/images/area_pelvis_0.png" alt="" />
+          <img src="./assets/images/area_pelvis_0.png" alt="Ilustración de cáncer de pelvis" />
           <span>Cáncer de Pelvis</span>
         </a>
 
         <a class="category-card" href="cabeza_cuello.html">
-          <img src="./assets/images/cabeza_cuello_0.png" alt="" />
+          <img src="./assets/images/cabeza_cuello_0.png" alt="Ilustración de cabeza y cuello" />
           <span>Cabeza y Cuello</span>
         </a>
 
         <a class="category-card" href="mama_torax.html">
-          <img src="./assets/images/mama_torax_0.png" alt="" />
+          <img src="./assets/images/mama_torax_0.png" alt="Ilustración de mama y tórax" />
           <span>Mama y Tórax</span>
         </a>
 
         <a class="category-card" href="tumores_snc.html">
-          <img src="./assets/images/tumores_snc_1.png" alt="" />
+          <img src="./assets/images/tumores_snc_1.png" alt="Ilustración de tumores del sistema nervioso central" />
           <span>Tumores SNC</span>
         </a>
 
         <a class="category-card" href="cancer_prostata.html">
-          <img src="./assets/images/cancer_prostata_0.png" alt="" />
+          <img src="./assets/images/cancer_prostata_0.png" alt="Ilustración de cáncer de próstata" />
           <span>Cáncer de Próstata</span>
         </a>
       </div>

--- a/mama_torax.html
+++ b/mama_torax.html
@@ -25,7 +25,7 @@
   </article>
 
   <figure class="image-card">
-    <img src="./assets/images/mama_torax_1.png" alt="" />
+    <img src="./assets/images/mama_torax_1.png" alt="Ilustración de radioterapia en mama y tórax" />
   </figure>
 
   <article class="section-card">
@@ -37,7 +37,7 @@
   </article>
 
   <figure class="image-card">
-    <img src="./assets/images/mama_torax_2.png" alt="" />
+    <img src="./assets/images/mama_torax_2.png" alt="Esquema de tratamiento para el tórax" />
   </figure>
 
   <article class="section-card">
@@ -53,7 +53,7 @@
   </article>
 
   <figure class="image-card">
-    <img src="./assets/images/mama_torax_3.png" alt="" />
+    <img src="./assets/images/mama_torax_3.png" alt="Gráfico de efectos secundarios en el tórax" />
   </figure>
 
   <article class="section-card">
@@ -110,7 +110,7 @@
   </article>
 
   <figure class="image-card">
-    <img src="./assets/images/mama_torax_4.png" alt="" />
+    <img src="./assets/images/mama_torax_4.png" alt="Imagen de linfedema en brazo" />
   </figure>
 
   <article class="section-card">

--- a/proteccion_radiologica.html
+++ b/proteccion_radiologica.html
@@ -21,7 +21,7 @@
   </article>
 
   <figure class="image-card">
-    <img src="./assets/images/proteccion_radiologica_1.png" alt="" />
+    <img src="./assets/images/proteccion_radiologica_1.png" alt="Infografía de protección radiológica" />
   </figure>
 
   <article class="section-card">
@@ -39,7 +39,7 @@
   </article>
 
   <figure class="image-card">
-    <img src="./assets/images/proteccion_radiologica_2.png" alt="" />
+    <img src="./assets/images/proteccion_radiologica_2.png" alt="Señalización de áreas de tratamiento" />
   </figure>
 
   <article class="section-card">
@@ -49,7 +49,7 @@
   </article>
 
   <figure class="image-card">
-    <img src="./assets/images/proteccion_radiologica_3.png" alt="" />
+    <img src="./assets/images/proteccion_radiologica_3.png" alt="Gráfico de zonas de control" />
   </figure>
 
   <article class="section-card">

--- a/tumores_snc.html
+++ b/tumores_snc.html
@@ -30,7 +30,7 @@
   </article>
 
   <figure class="image-card">
-    <img src="./assets/images/tumores_snc_1.png" alt="" />
+    <img src="./assets/images/tumores_snc_1.png" alt="Ilustración del sistema nervioso central" />
   </figure>
 
   <article class="section-card">
@@ -44,7 +44,7 @@
   </article>
 
   <figure class="image-card">
-    <img src="./assets/images/tumores_snc_2.png" alt="" />
+    <img src="./assets/images/tumores_snc_2.png" alt="Gráfico de síntomas de tumores cerebrales" />
   </figure>
 
   <article class="section-card">
@@ -57,7 +57,7 @@
   </article>
 
   <figure class="image-card">
-    <img src="./assets/images/tumores_snc_3.png" alt="" />
+    <img src="./assets/images/tumores_snc_3.png" alt="Ilustración de síntomas de tumores espinales" />
   </figure>
 
   <article class="section-card">


### PR DESCRIPTION
## Summary
- Replace empty image alt attributes with short, descriptive text across all HTML pages
- Reserve empty alt text for decorative assets only

## Testing
- `rg 'alt=""' -n`
- `npx @axe-core/cli index.html` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@axe-core%2fcli)*

------
https://chatgpt.com/codex/tasks/task_e_689fe3f824a08333b8d8475ce793ea8e