### PR TITLE
Scale category cards on small screens

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -186,5 +186,7 @@ body {
   html { --font-size: 14px; }
   .app-header { padding: .75rem; }
   .category-grid { grid-template-columns: 1fr; padding: .5rem; }
+  .category-card { transform: scale(0.9); }
+  .category-card span { font-size:0.85rem; }
   .section-card { margin: .5rem; padding: .5rem; }
 }


### PR DESCRIPTION
## Summary
- Shrink category cards and reduce caption text at 480px breakpoint for improved mobile layout.

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689fe671d34483338e06a19d41f2f31e