### PR TITLE
Add responsive back navigation to content pages

### DIFF
--- a/back.js
+++ b/back.js
@@ -1,0 +1,6 @@
+(function () {
+  const btn = document.querySelector('.back-arrow');
+  if (btn) {
+    btn.addEventListener('click', () => window.history.back());
+  }
+})();

--- a/cabeza_cuello.html
+++ b/cabeza_cuello.html
@@ -9,6 +9,7 @@
 </head>
 <body>
   <header class="section-header" style="background-color:#ff9800">
+    <button class="back-arrow material-icons">arrow_back</button>
     <span class="material-icons icon">psychology</span>
     <h2>Cabeza y Cuello</h2>
     <p>Para pacientes con Cáncer de Cabeza y Cuello</p>
@@ -138,5 +139,6 @@
     <span class="material-icons">format_size</span>
   </button>
   <script src="font.js"></script>
+  <script src="back.js"></script>
 </body>
 </html>

--- a/cancer_gastrico.html
+++ b/cancer_gastrico.html
@@ -9,6 +9,7 @@
 </head>
 <body>
   <header class="section-header" style="background-color:#009688">
+    <button class="back-arrow material-icons">arrow_back</button>
     <span class="material-icons icon">local_hospital</span>
     <h2>Cáncer Gástrico</h2>
     <p>Para pacientes con Cáncer Gástrico</p>
@@ -110,5 +111,6 @@
     <span class="material-icons">format_size</span>
   </button>
   <script src="font.js"></script>
+  <script src="back.js"></script>
 </body>
 </html>

--- a/cancer_pelvis.html
+++ b/cancer_pelvis.html
@@ -9,6 +9,7 @@
 </head>
 <body>
   <header class="section-header" style="background-color:#9c27b0">
+    <button class="back-arrow material-icons">arrow_back</button>
     <span class="material-icons icon">healing</span>
     <h2>Cáncer de Pelvis</h2>
     <p>Para pacientes con Cáncer de Pelvis</p>
@@ -103,5 +104,6 @@
     <span class="material-icons">format_size</span>
   </button>
   <script src="font.js"></script>
+  <script src="back.js"></script>
 </body>
 </html>

--- a/cancer_prostata.html
+++ b/cancer_prostata.html
@@ -9,6 +9,7 @@
 </head>
 <body>
   <header class="section-header" style="background-color:#1ac3e9">
+    <button class="back-arrow material-icons">arrow_back</button>
     <span class="material-icons icon">male</span>
     <h2>Cáncer de Próstata</h2>
     <p>Información general</p>
@@ -100,5 +101,6 @@
     <span class="material-icons">format_size</span>
   </button>
   <script src="font.js"></script>
+  <script src="back.js"></script>
 </body>
 </html>

--- a/mama_torax.html
+++ b/mama_torax.html
@@ -9,6 +9,7 @@
 </head>
 <body>
   <header class="section-header" style="background-color:#e91e63">
+    <button class="back-arrow material-icons">arrow_back</button>
     <span class="material-icons icon">favorite</span>
     <h2>Mama y Tórax</h2>
     <p>Para pacientes con Cáncer de Mama o Tórax</p>
@@ -127,5 +128,6 @@
     <span class="material-icons">format_size</span>
   </button>
   <script src="font.js"></script>
+  <script src="back.js"></script>
 </body>
 </html>

--- a/proteccion_radiologica.html
+++ b/proteccion_radiologica.html
@@ -9,6 +9,7 @@
 </head>
 <body>
   <header class="section-header" style="background-color:#eaae3a">
+    <button class="back-arrow material-icons">arrow_back</button>
     <span class="material-icons icon">medical_services</span>
     <h2>Protección Radiológica</h2>
     <p>Información al paciente</p>
@@ -86,5 +87,6 @@
     <span class="material-icons">format_size</span>
   </button>
   <script src="font.js"></script>
+  <script src="back.js"></script>
 </body>
 </html>

--- a/styles.css
+++ b/styles.css
@@ -188,3 +188,5 @@ body {
   .category-grid { grid-template-columns: 1fr; padding: .5rem; }
   .section-card { margin: .5rem; padding: .5rem; }
 }
+.back-arrow { position:absolute; left:0.5rem; top:0.5rem; display:none; background:none; border:none; }
+@media (max-width:768px) { .section-header { position:relative; } .back-arrow { display:block; } }

--- a/tumores_snc.html
+++ b/tumores_snc.html
@@ -9,6 +9,7 @@
 </head>
 <body>
   <header class="section-header" style="background-color:#eaae3a">
+    <button class="back-arrow material-icons">arrow_back</button>
     <span class="material-icons icon">psychology</span>
     <h2>TUMORES</h2>
     <p>Sistema Nervioso Central (SNC)</p>
@@ -89,5 +90,6 @@
     <span class="material-icons">format_size</span>
   </button>
   <script src="font.js"></script>
+  <script src="back.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add back arrow buttons to content page headers for easier navigation
- include responsive styles for back arrow visibility on mobile
- add small script to navigate back on arrow click and include on all content pages

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689fe67073e083338cc98cfe3bc80563