### PR TITLE
Integrate Google Analytics gtag

### DIFF
--- a/analytics.js
+++ b/analytics.js
@@ -1,0 +1,4 @@
+window.dataLayer = window.dataLayer || [];
+function gtag(){dataLayer.push(arguments);}
+gtag('js', new Date());
+gtag('config', 'G-8RY2NB2PPW');

--- a/cabeza_cuello.html
+++ b/cabeza_cuello.html
@@ -138,5 +138,8 @@
     <span class="material-icons">format_size</span>
   </button>
   <script src="font.js"></script>
+  <!-- Google tag (gtag.js) -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-8RY2NB2PPW"></script>
+  <script src="analytics.js"></script>
 </body>
 </html>

--- a/cancer_gastrico.html
+++ b/cancer_gastrico.html
@@ -110,5 +110,8 @@
     <span class="material-icons">format_size</span>
   </button>
   <script src="font.js"></script>
+  <!-- Google tag (gtag.js) -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-8RY2NB2PPW"></script>
+  <script src="analytics.js"></script>
 </body>
 </html>

--- a/cancer_pelvis.html
+++ b/cancer_pelvis.html
@@ -103,5 +103,8 @@
     <span class="material-icons">format_size</span>
   </button>
   <script src="font.js"></script>
+  <!-- Google tag (gtag.js) -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-8RY2NB2PPW"></script>
+  <script src="analytics.js"></script>
 </body>
 </html>

--- a/cancer_prostata.html
+++ b/cancer_prostata.html
@@ -100,5 +100,8 @@
     <span class="material-icons">format_size</span>
   </button>
   <script src="font.js"></script>
+  <!-- Google tag (gtag.js) -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-8RY2NB2PPW"></script>
+  <script src="analytics.js"></script>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -63,5 +63,8 @@
     <span class="material-icons">format_size</span>
   </button>
   <script src="font.js"></script>
+  <!-- Google tag (gtag.js) -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-8RY2NB2PPW"></script>
+  <script src="analytics.js"></script>
 </body>
 </html>

--- a/mama_torax.html
+++ b/mama_torax.html
@@ -127,5 +127,8 @@
     <span class="material-icons">format_size</span>
   </button>
   <script src="font.js"></script>
+  <!-- Google tag (gtag.js) -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-8RY2NB2PPW"></script>
+  <script src="analytics.js"></script>
 </body>
 </html>

--- a/proteccion_radiologica.html
+++ b/proteccion_radiologica.html
@@ -86,5 +86,8 @@
     <span class="material-icons">format_size</span>
   </button>
   <script src="font.js"></script>
+  <!-- Google tag (gtag.js) -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-8RY2NB2PPW"></script>
+  <script src="analytics.js"></script>
 </body>
 </html>

--- a/tumores_snc.html
+++ b/tumores_snc.html
@@ -89,5 +89,8 @@
     <span class="material-icons">format_size</span>
   </button>
   <script src="font.js"></script>
+  <!-- Google tag (gtag.js) -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-8RY2NB2PPW"></script>
+  <script src="analytics.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- Replace custom analytics logic with Google Analytics initialization.
- Load Google tag and analytics script on index and content pages for tracking.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689fe6704c4c83338fa3323a23ffc2d4