### PR TITLE
Improve mobile navigation and menu layout

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -49,7 +49,7 @@ body {
   overflow: hidden;
   text-decoration: none;
   color: inherit;
-  transition: box-shadow .3s, transform .3s;
+  transition: box-shadow .3s;
   min-width: 44px;
   min-height: 44px;
 }
@@ -72,11 +72,9 @@ body {
 }
 .category-card:hover {
   box-shadow: 0 6px 12px rgba(0,0,0,0.3);
-  transform: translateY(-2px);
 }
 .category-card:active {
   box-shadow: var(--shadow-sm);
-  transform: none;
 }
 
 /* Content pages */
@@ -185,10 +183,10 @@ body {
 @media (max-width:480px) {
   html { --font-size: 14px; }
   .app-header { padding: .75rem; }
-  .category-grid { grid-template-columns: 1fr; padding: .5rem; }
+  .category-grid { grid-template-columns: repeat(2,1fr); padding: .5rem; }
   .category-card { transform: scale(0.9); }
   .category-card span { font-size:0.85rem; }
   .section-card { margin: .5rem; padding: .5rem; }
 }
-.back-arrow { position:absolute; left:0.5rem; top:0.5rem; display:none; background:none; border:none; }
+.back-arrow { position:absolute; left:0.5rem; top:0.5rem; display:none; background:none; border:none; font-size:2rem; cursor:pointer; }
 @media (max-width:768px) { .section-header { position:relative; } .back-arrow { display:block; } }


### PR DESCRIPTION
## Summary
- Enlarge back button icon for better visibility on small screens
- Remove hover scaling so menu cards no longer grow on mobile
- Display menu cards in two columns on narrow viewports

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689fe98174dc8333b019568d1cb2f1e9