### PR TITLE
Add fixed top nav and restore page headers

### DIFF
--- a/cabeza_cuello.html
+++ b/cabeza_cuello.html
@@ -8,8 +8,11 @@
   <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
 </head>
 <body>
-  <header class="section-header" style="background-color:#ff9800">
+  <header class="top-header" style="background-color:#ff9800">
     <button class="back-arrow material-icons">arrow_back</button>
+    <h1>Cabeza y Cuello</h1>
+  </header>
+  <header class="section-header" style="background-color:#ff9800">
     <span class="material-icons icon">psychology</span>
     <h2>Cabeza y Cuello</h2>
     <p>Para pacientes con Cáncer de Cabeza y Cuello</p>

--- a/cancer_gastrico.html
+++ b/cancer_gastrico.html
@@ -8,8 +8,11 @@
   <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
 </head>
 <body>
-  <header class="section-header" style="background-color:#009688">
+  <header class="top-header" style="background-color:#009688">
     <button class="back-arrow material-icons">arrow_back</button>
+    <h1>Cáncer Gástrico</h1>
+  </header>
+  <header class="section-header" style="background-color:#009688">
     <span class="material-icons icon">local_hospital</span>
     <h2>Cáncer Gástrico</h2>
     <p>Para pacientes con Cáncer Gástrico</p>

--- a/cancer_pelvis.html
+++ b/cancer_pelvis.html
@@ -8,8 +8,11 @@
   <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
 </head>
 <body>
-  <header class="section-header" style="background-color:#9c27b0">
+  <header class="top-header" style="background-color:#9c27b0">
     <button class="back-arrow material-icons">arrow_back</button>
+    <h1>Cáncer de Pelvis</h1>
+  </header>
+  <header class="section-header" style="background-color:#9c27b0">
     <span class="material-icons icon">healing</span>
     <h2>Cáncer de Pelvis</h2>
     <p>Para pacientes con Cáncer de Pelvis</p>

--- a/cancer_prostata.html
+++ b/cancer_prostata.html
@@ -8,8 +8,11 @@
   <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
 </head>
 <body>
-  <header class="section-header" style="background-color:#1ac3e9">
+  <header class="top-header" style="background-color:#1ac3e9">
     <button class="back-arrow material-icons">arrow_back</button>
+    <h1>Cáncer de Próstata</h1>
+  </header>
+  <header class="section-header" style="background-color:#1ac3e9">
     <span class="material-icons icon">male</span>
     <h2>Cáncer de Próstata</h2>
     <p>Información general</p>

--- a/mama_torax.html
+++ b/mama_torax.html
@@ -8,8 +8,11 @@
   <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
 </head>
 <body>
-  <header class="section-header" style="background-color:#e91e63">
+  <header class="top-header" style="background-color:#e91e63">
     <button class="back-arrow material-icons">arrow_back</button>
+    <h1>Mama y Tórax</h1>
+  </header>
+  <header class="section-header" style="background-color:#e91e63">
     <span class="material-icons icon">favorite</span>
     <h2>Mama y Tórax</h2>
     <p>Para pacientes con Cáncer de Mama o Tórax</p>

--- a/proteccion_radiologica.html
+++ b/proteccion_radiologica.html
@@ -8,8 +8,11 @@
   <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
 </head>
 <body>
-  <header class="section-header" style="background-color:#eaae3a">
+  <header class="top-header" style="background-color:#eaae3a">
     <button class="back-arrow material-icons">arrow_back</button>
+    <h1>Protección Radiológica</h1>
+  </header>
+  <header class="section-header" style="background-color:#eaae3a">
     <span class="material-icons icon">medical_services</span>
     <h2>Protección Radiológica</h2>
     <p>Información al paciente</p>

--- a/styles.css
+++ b/styles.css
@@ -22,21 +22,29 @@ body {
 .app-header {
   background: var(--color-primary);
   color: #fff;
-  text-align: center;
-  padding: 1rem;
+  padding: 0.5rem 1rem;
   display: flex;
-  flex-direction: column;
   align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+  position: sticky;
+  top: 0;
+  z-index: 1000;
 }
 .app-header .logo {
-  height: 50px;
-  margin-bottom: 0.5rem;
+  height: 40px;
+  margin: 0;
+}
+.site-title {
+  font-size: 1.25rem;
+  margin: 0;
+  text-align: center;
 }
 
 .category-grid {
   display: grid;
   grid-template-columns: repeat(auto-fill,minmax(200px,1fr));
-  gap: 1rem;
+  gap: 1.5rem;
   padding: 1rem;
 }
 .category-card {
@@ -77,6 +85,31 @@ body {
   box-shadow: var(--shadow-sm);
 }
 
+/* Top bar for content pages */
+.top-header {
+  color: #fff;
+  padding: 0.75rem 1rem;
+  display: flex;
+  align-items: center;
+  position: sticky;
+  top: 0;
+  z-index: 1000;
+}
+.top-header h1 {
+  flex: 1;
+  margin: 0;
+  text-align: center;
+  font-size: 1.25rem;
+}
+
+.back-arrow {
+  background: none;
+  border: none;
+  font-size: 2rem;
+  cursor: pointer;
+  color: inherit;
+}
+
 /* Content pages */
 .section-header {
   color: #fff;
@@ -98,7 +131,7 @@ body {
 
 .section-card {
   background: var(--color-surface);
-  margin: 1rem;
+  margin: 1.5rem;
   padding: 1rem;
   border-radius: 12px;
   box-shadow: var(--shadow-sm);
@@ -123,7 +156,7 @@ body {
   margin-bottom: 0.5rem;
 }
 .image-card {
-  margin: 1rem;
+  margin: 1.5rem;
   border-radius: 12px;
   overflow: hidden;
   box-shadow: var(--shadow-sm);
@@ -176,17 +209,17 @@ body {
 
 @media (max-width:768px) {
   html { --font-size: 15px; }
-  .category-grid { grid-template-columns: repeat(auto-fill,minmax(150px,1fr)); padding: .75rem; }
-  .section-card { margin: .75rem; padding: .75rem; }
+  .category-grid { grid-template-columns: repeat(auto-fill,minmax(150px,1fr)); padding: .75rem; gap: 1.25rem; }
+  .section-card { margin: 1.25rem; padding: .75rem; }
+  .image-card { margin: 1.25rem; }
 }
 
 @media (max-width:480px) {
   html { --font-size: 14px; }
-  .app-header { padding: .75rem; }
-  .category-grid { grid-template-columns: repeat(2,1fr); padding: .5rem; }
+  .app-header { padding: 0.5rem 0.75rem; }
+  .category-grid { grid-template-columns: repeat(2,1fr); padding: .5rem; gap: 1rem; }
   .category-card { transform: scale(0.9); }
   .category-card span { font-size:0.85rem; }
-  .section-card { margin: .5rem; padding: .5rem; }
+  .section-card { margin: 1rem; padding: .5rem; }
+  .image-card { margin: 1rem; }
 }
-.back-arrow { position:absolute; left:0.5rem; top:0.5rem; display:none; background:none; border:none; font-size:2rem; cursor:pointer; }
-@media (max-width:768px) { .section-header { position:relative; } .back-arrow { display:block; } }

--- a/tumores_snc.html
+++ b/tumores_snc.html
@@ -8,8 +8,11 @@
   <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
 </head>
 <body>
-  <header class="section-header" style="background-color:#eaae3a">
+  <header class="top-header" style="background-color:#eaae3a">
     <button class="back-arrow material-icons">arrow_back</button>
+    <h1>Tumores SNC</h1>
+  </header>
+  <header class="section-header" style="background-color:#eaae3a">
     <span class="material-icons icon">psychology</span>
     <h2>TUMORES</h2>
     <p>Sistema Nervioso Central (SNC)</p>


### PR DESCRIPTION
## Summary
- Allow the home screen header to wrap across lines while keeping the logo vertically centered
- Add a fixed top bar with back button and title, keeping existing headers with icons and descriptions below
- Maintain expanded spacing around cards for clearer separation

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689febda56288333876b6c20aa44bbad