### PR TITLE
Revamp section headers on content pages

### DIFF
--- a/cabeza_cuello.html
+++ b/cabeza_cuello.html
@@ -8,13 +8,10 @@
   <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
 </head>
 <body>
-  <header class="top-header" style="background-color:#ff9800">
-    <button class="back-arrow material-icons">arrow_back</button>
-    <h1>Cabeza y Cuello</h1>
-  </header>
   <header class="section-header" style="background-color:#ff9800">
+    <button class="back-arrow material-icons">arrow_back</button>
     <span class="material-icons icon">psychology</span>
-    <h2>Cabeza y Cuello</h2>
+    <h1>Cabeza y Cuello</h1>
   </header>
 
   <article class="section-card">

--- a/cancer_gastrico.html
+++ b/cancer_gastrico.html
@@ -8,13 +8,10 @@
   <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
 </head>
 <body>
-  <header class="top-header" style="background-color:#009688">
-    <button class="back-arrow material-icons">arrow_back</button>
-    <h1>Cáncer Gástrico</h1>
-  </header>
   <header class="section-header" style="background-color:#009688">
+    <button class="back-arrow material-icons">arrow_back</button>
     <span class="material-icons icon">local_hospital</span>
-    <h2>Cáncer Gástrico</h2>
+    <h1>Cáncer Gástrico</h1>
   </header>
 
   <article class="section-card">

--- a/cancer_pelvis.html
+++ b/cancer_pelvis.html
@@ -8,13 +8,10 @@
   <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
 </head>
 <body>
-  <header class="top-header" style="background-color:#9c27b0">
-    <button class="back-arrow material-icons">arrow_back</button>
-    <h1>Cáncer de Pelvis</h1>
-  </header>
   <header class="section-header" style="background-color:#9c27b0">
+    <button class="back-arrow material-icons">arrow_back</button>
     <span class="material-icons icon">healing</span>
-    <h2>Cáncer de Pelvis</h2>
+    <h1>Cáncer de Pelvis</h1>
   </header>
 
   <article class="section-card">

--- a/cancer_prostata.html
+++ b/cancer_prostata.html
@@ -8,13 +8,10 @@
   <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
 </head>
 <body>
-  <header class="top-header" style="background-color:#1ac3e9">
-    <button class="back-arrow material-icons">arrow_back</button>
-    <h1>Cáncer de Próstata</h1>
-  </header>
   <header class="section-header" style="background-color:#1ac3e9">
+    <button class="back-arrow material-icons">arrow_back</button>
     <span class="material-icons icon">male</span>
-    <h2>Cáncer de Próstata</h2>
+    <h1>Cáncer de Próstata</h1>
   </header>
 
   <article class="section-card">

--- a/mama_torax.html
+++ b/mama_torax.html
@@ -8,13 +8,10 @@
   <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
 </head>
 <body>
-  <header class="top-header" style="background-color:#e91e63">
-    <button class="back-arrow material-icons">arrow_back</button>
-    <h1>Mama y Tórax</h1>
-  </header>
   <header class="section-header" style="background-color:#e91e63">
+    <button class="back-arrow material-icons">arrow_back</button>
     <span class="material-icons icon">favorite</span>
-    <h2>Mama y Tórax</h2>
+    <h1>Mama y Tórax</h1>
   </header>
 
   <article class="section-card">

--- a/proteccion_radiologica.html
+++ b/proteccion_radiologica.html
@@ -8,13 +8,10 @@
   <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
 </head>
 <body>
-  <header class="top-header" style="background-color:#eaae3a">
-    <button class="back-arrow material-icons">arrow_back</button>
-    <h1>Protección Radiológica</h1>
-  </header>
   <header class="section-header" style="background-color:#eaae3a">
+    <button class="back-arrow material-icons">arrow_back</button>
     <span class="material-icons icon">medical_services</span>
-    <h2>Protección Radiológica</h2>
+    <h1>Protección Radiológica</h1>
   </header>
 
   <article class="section-card">

--- a/styles.css
+++ b/styles.css
@@ -91,56 +91,42 @@ body {
   box-shadow: var(--shadow-sm);
 }
 
-/* Top bar for content pages */
-.top-header {
-  color: #fff;
-  padding: 0.75rem 1rem;
-  display: flex;
-  align-items: center;
-  position: sticky;
-  top: 0;
-  z-index: 1000;
-}
-.top-header h1 {
-  flex: 1;
-  margin: 0;
-  text-align: center;
-  font-size: 1.25rem;
-}
-
-.back-arrow {
-  background: none;
-  border: none;
-  font-size: 2rem;
-  cursor: pointer;
-  color: inherit;
-}
-
-/* Content pages */
+/* Content page header */
 .section-header {
   color: #fff;
   padding: 0.75rem 1rem;
   display: flex;
+  flex-direction: column;
   align-items: center;
   position: sticky;
   top: 0;
   z-index: 1000;
-}
-.section-header .icon,
-.section-header p {
-  display: none;
-}
-.section-header h2 {
-  flex: 1;
-  margin: 0;
   text-align: center;
 }
+
 .section-header .back-arrow {
+  align-self: flex-start;
   background: none;
   border: none;
   font-size: 2rem;
   cursor: pointer;
   color: inherit;
+  padding: 0;
+  line-height: 1;
+  -webkit-appearance: none;
+}
+
+.section-header .icon {
+  font-size: 3rem;
+  margin: 0.5rem 0;
+}
+
+.section-header h1 {
+  margin: 0;
+}
+
+.section-header p {
+  margin: 0.25rem 0 0;
 }
 
 .section-title {

--- a/tumores_snc.html
+++ b/tumores_snc.html
@@ -8,13 +8,10 @@
   <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
 </head>
 <body>
-  <header class="top-header" style="background-color:#eaae3a">
-    <button class="back-arrow material-icons">arrow_back</button>
-    <h1>Tumores SNC</h1>
-  </header>
   <header class="section-header" style="background-color:#eaae3a">
+    <button class="back-arrow material-icons">arrow_back</button>
     <span class="material-icons icon">psychology</span>
-    <h2>TUMORES</h2>
+    <h1>Tumores SNC</h1>
   </header>
 
   <article class="section-card">


### PR DESCRIPTION
## Summary
- Merge top and section headers on content pages into a single cohesive header
- Expose material icons and cleaned up back arrow styling for consistent mobile look

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689ff1f62590833387d8db46b51aa46e