### PR TITLE
Back button returns to index and taller headers

### DIFF
--- a/back.js
+++ b/back.js
@@ -1,6 +1,8 @@
 (function () {
   const btn = document.querySelector('.back-arrow');
   if (btn) {
-    btn.addEventListener('click', () => window.history.back());
+    btn.addEventListener('click', () => {
+      window.location.href = 'index.html';
+    });
   }
 })();

--- a/styles.css
+++ b/styles.css
@@ -28,7 +28,7 @@ body {
 .app-header {
   background: var(--color-primary);
   color: #fff;
-  padding: 0.25rem 1rem;
+  padding: 0.35rem 1rem;
   display: flex;
   align-items: center;
   justify-content: center;
@@ -97,7 +97,7 @@ body {
 /* Content page header */
 .section-header {
   color: #fff;
-  padding: 0.25rem 0.75rem;
+  padding: 0.35rem 0.75rem;
   display: flex;
   align-items: center;
   gap: 0.5rem;
@@ -223,7 +223,7 @@ body {
 
 @media (max-width:480px) {
   html { --font-size: 14px; }
-  .app-header { padding: 0.5rem 0.75rem; }
+  .app-header { padding: 0.675rem 0.75rem; }
   .category-grid { grid-template-columns: repeat(2,1fr); padding: .5rem; gap: 1rem; }
   .category-card { transform: scale(0.9); }
   .category-card span { font-size:0.85rem; }


### PR DESCRIPTION
## Summary
- Route back arrow to index page instead of browser history
- Increase top bar padding ~35% on home and section headers
- Adjust mobile header padding for a taller appearance

## Testing
- `npm test` *(fails: ENOENT, package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_689ffa5b9ecc83338465e447859eaf55