### PR TITLE
Add service worker for offline support

### DIFF
--- a/cabeza_cuello.html
+++ b/cabeza_cuello.html
@@ -142,5 +142,6 @@
   <script async src="https://www.googletagmanager.com/gtag/js?id=G-8RY2NB2PPW"></script>
   <script src="analytics.js"></script>
   <script src="back.js"></script>
+  <script src="sw-register.js"></script>
 </body>
 </html>

--- a/cancer_gastrico.html
+++ b/cancer_gastrico.html
@@ -114,5 +114,6 @@
   <script async src="https://www.googletagmanager.com/gtag/js?id=G-8RY2NB2PPW"></script>
   <script src="analytics.js"></script>
   <script src="back.js"></script>
+  <script src="sw-register.js"></script>
 </body>
 </html>

--- a/cancer_pelvis.html
+++ b/cancer_pelvis.html
@@ -107,5 +107,6 @@
   <script async src="https://www.googletagmanager.com/gtag/js?id=G-8RY2NB2PPW"></script>
   <script src="analytics.js"></script>
   <script src="back.js"></script>
+  <script src="sw-register.js"></script>
 </body>
 </html>

--- a/cancer_prostata.html
+++ b/cancer_prostata.html
@@ -104,5 +104,6 @@
   <script async src="https://www.googletagmanager.com/gtag/js?id=G-8RY2NB2PPW"></script>
   <script src="analytics.js"></script>
   <script src="back.js"></script>
+  <script src="sw-register.js"></script>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -68,5 +68,6 @@
   <!-- Google tag (gtag.js) -->
   <script async src="https://www.googletagmanager.com/gtag/js?id=G-8RY2NB2PPW"></script>
   <script src="analytics.js"></script>
+  <script src="sw-register.js"></script>
 </body>
 </html>

--- a/mama_torax.html
+++ b/mama_torax.html
@@ -131,5 +131,6 @@
   <script async src="https://www.googletagmanager.com/gtag/js?id=G-8RY2NB2PPW"></script>
   <script src="analytics.js"></script>
   <script src="back.js"></script>
+  <script src="sw-register.js"></script>
 </body>
 </html>

--- a/offline.html
+++ b/offline.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Sin conexión</title>
+  <link rel="stylesheet" href="styles.css" />
+  <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
+</head>
+<body>
+  <header class="section-header" style="background-color:#009688">
+    <span class="material-icons icon">cloud_off</span>
+    <h1>Sin conexión</h1>
+  </header>
+  <article class="section-card">
+    <p>No hay conexión a internet. El contenido visitado previamente seguirá disponible.</p>
+    <p>Intente reconectarse para acceder a la información más reciente.</p>
+  </article>
+</body>
+</html>

--- a/proteccion_radiologica.html
+++ b/proteccion_radiologica.html
@@ -90,5 +90,6 @@
   <script async src="https://www.googletagmanager.com/gtag/js?id=G-8RY2NB2PPW"></script>
   <script src="analytics.js"></script>
   <script src="back.js"></script>
+  <script src="sw-register.js"></script>
 </body>
 </html>

--- a/service-worker.js
+++ b/service-worker.js
@@ -1,0 +1,48 @@
+const CACHE_NAME = 'offline-cache-v1';
+const OFFLINE_URL = 'offline.html';
+const URLS_TO_CACHE = [
+  '/',
+  'index.html',
+  'styles.css',
+  'font.js',
+  'analytics.js',
+  'back.js',
+  'offline.html',
+  'cabeza_cuello.html',
+  'cancer_gastrico.html',
+  'cancer_pelvis.html',
+  'cancer_prostata.html',
+  'mama_torax.html',
+  'proteccion_radiologica.html',
+  'tumores_snc.html'
+];
+
+self.addEventListener('install', event => {
+  event.waitUntil(
+    caches.open(CACHE_NAME).then(cache => cache.addAll(URLS_TO_CACHE))
+  );
+  self.skipWaiting();
+});
+
+self.addEventListener('activate', event => {
+  event.waitUntil(
+    caches.keys().then(keys =>
+      Promise.all(keys.filter(key => key !== CACHE_NAME).map(key => caches.delete(key)))
+    )
+  );
+  self.clients.claim();
+});
+
+self.addEventListener('fetch', event => {
+  if (event.request.mode === 'navigate') {
+    event.respondWith(
+      fetch(event.request).catch(() =>
+        caches.match(event.request).then(response => response || caches.match(OFFLINE_URL))
+      )
+    );
+  } else {
+    event.respondWith(
+      caches.match(event.request).then(response => response || fetch(event.request))
+    );
+  }
+});

--- a/sw-register.js
+++ b/sw-register.js
@@ -1,0 +1,5 @@
+if ('serviceWorker' in navigator) {
+  window.addEventListener('load', function() {
+    navigator.serviceWorker.register('service-worker.js');
+  });
+}

--- a/tumores_snc.html
+++ b/tumores_snc.html
@@ -93,5 +93,6 @@
   <script async src="https://www.googletagmanager.com/gtag/js?id=G-8RY2NB2PPW"></script>
   <script src="analytics.js"></script>
   <script src="back.js"></script>
+  <script src="sw-register.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- cache site pages and assets with a service worker
- serve offline fallback page when network is unavailable
- register service worker across all pages for offline support

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a002afd9f48333837a5e73b0867bae